### PR TITLE
Avoid floating point for advancing metronome.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-ex
 find . -name "*.profraw" -delete
 xdg-open target/coverage/html/html/index.html
 ```
+
+### Benchmarking
+
+Microbenchmarks are built using criterion and can be run with `cargo bench`. Additionally, flamegraphs can be made with `cargo flamegraph`.
+
+```
+# Creates flamegraph.svg after program exits.
+cargo flamegraph
+```

--- a/bats-lib/src/position.rs
+++ b/bats-lib/src/position.rs
@@ -1,8 +1,10 @@
 /// Position contains the position within the transport. This includes
 /// a beat and sub_beat component.
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Default, PartialEq)]
 pub struct Position {
-    beat: f64,
+    /// The beat where the top 32bits represent the beat and the bottom 32 bits represents the sub
+    /// beat.
+    beat: u64,
 }
 
 impl Position {
@@ -10,17 +12,21 @@ impl Position {
     /// `sub_beat` is greater than 0, than it is converted into the
     /// appropriate amount of beats.
     pub fn new(beat: f64) -> Position {
-        Position { beat }
+        let higher = (beat.trunc() as u64) << 32;
+        let lower = (beat.fract() * (1u64 << 32) as f64) as u32;
+        Position {
+            beat: higher + lower as u64,
+        }
     }
 
     /// Get the beat for `self`.
     pub fn beat(&self) -> u32 {
-        self.beat.trunc() as u32
+        (self.beat >> 32) as u32
     }
 
     /// Get the sub beat for `self`.
-    pub fn sub_beat(&self) -> f64 {
-        self.beat.fract()
+    pub fn sub_beat(&self) -> u32 {
+        (self.beat & 0x00000000FFFFFFFF) as u32
     }
 }
 
@@ -40,6 +46,17 @@ impl std::ops::AddAssign for Position {
     }
 }
 
+impl std::fmt::Debug for Position {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let beat = self.beat();
+        let sub_beat = self.sub_beat();
+        f.debug_struct("Position")
+            .field("beat", &beat)
+            .field("sub_beat", &sub_beat)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,14 +65,14 @@ mod tests {
     fn default_value_is_zero() {
         assert_eq!(Position::default(), Position::new(0.0));
         assert_eq!(Position::default().beat(), 0);
-        assert_eq!(Position::default().sub_beat(), 0.0);
+        assert_eq!(Position::default().sub_beat(), 0);
     }
 
     #[test]
     fn new_beat_position_with_has_beat_and_sub_beat() {
         let p = Position::new(11.5);
         assert_eq!(p.beat(), 11);
-        assert_eq!(p.sub_beat(), 0.5);
+        assert_eq!(p.sub_beat(), ((1u64 << 32) / 2) as u32);
     }
 
     #[test]


### PR DESCRIPTION
This converts the `Position` struct from an `f64` to a `(u32, u32)` pair. Additionally, the `u32` fields are combined into a single `u64` field to allow summing with a single addition operation without adding extra carrying logic instructions.